### PR TITLE
Make testing clones hermetic, however the source is specified

### DIFF
--- a/giterator/git.py
+++ b/giterator/git.py
@@ -1,7 +1,7 @@
 from os import makedirs
 from pathlib import Path
 from subprocess import check_output, STDOUT, CalledProcessError
-from typing import Union, Dict, List, Optional
+from typing import Union, Dict, List, Optional, Type, TypeVar
 
 from .typing import Date
 
@@ -20,6 +20,9 @@ class GitError(Exception):
     """
     Something went wrong while running a git command.
     """
+
+
+GitType = TypeVar('GitType', bound='Git')
 
 
 class Git:
@@ -77,7 +80,23 @@ class Git:
         self._set_user(user)
 
     @classmethod
-    def clone(cls, source: Union[str, Path, 'Git'], path: Union[str, Path], user: User = None):
+    def clone(
+            cls: Type[GitType],
+            source: Union[str, Path, 'Git'],
+            path: Union[str, Path],
+            user: User = None,
+    ) -> GitType:
+        """
+        Clone the ``source`` repo to the ``path`` specified.
+
+        :param source: The repo to clone, either as a path or a :class:`Git` instance.
+        :param path: Where to clone to. Relative paths are resolved relative to the
+            parent of ``source``.
+        :param user: The user to configure in the local clone. If not specified and
+            ``source`` is a :class:`Git` instance, the user from ``source``, if any,
+            is configured. Otherwise, no user is configured and commits in the clone
+            will depend on git's normal identity discovery.
+        """
         if isinstance(source, Git):
             user = user or source._user
             source = source.path

--- a/giterator/testing.py
+++ b/giterator/testing.py
@@ -20,7 +20,7 @@ class Repo(Git):
         self._clock = Clock()
 
     @classmethod
-    def make(cls, path: Union[Path, str], user: User = None):
+    def make(cls, path: Union[Path, str], user: User = None) -> 'Repo':
         """
         Make a repo at the path specified and ensure a user is configured
         in the repo. The user can be specified.
@@ -30,7 +30,9 @@ class Repo(Git):
         return repo
 
     @classmethod
-    def clone(cls, source: Union[str, Path, Git], path: Union[str, Path], user: User = None):
+    def clone(
+            cls, source: Union[str, Path, Git], path: Union[str, Path], user: User = None
+    ) -> 'Repo':
         """
         As :meth:`Git.clone`, but always ensures a user is configured in the
         clone, so commits made in it never depend on the machine's global git

--- a/giterator/testing.py
+++ b/giterator/testing.py
@@ -7,6 +7,9 @@ from .git import Git, User
 from .typing import Date
 
 
+DEFAULT_USER = User(name='Giterator', email='giterator@example.com')
+
+
 class Repo(Git):
     """
     A repo for use in automated tests.
@@ -23,7 +26,21 @@ class Repo(Git):
         in the repo. The user can be specified.
         """
         repo = cls(path)
-        repo.init(user or User(name='Giterator', email='giterator@example.com'))
+        repo.init(user or DEFAULT_USER)
+        return repo
+
+    @classmethod
+    def clone(cls, source: Union[str, Path, Git], path: Union[str, Path], user: User = None):
+        """
+        As :meth:`Git.clone`, but always ensures a user is configured in the
+        clone, so commits made in it never depend on the machine's global git
+        config. The user can be specified, and is otherwise inherited from a
+        :class:`Git` ``source``; failing both, the same default as :meth:`make`
+        is used.
+        """
+        repo = super().clone(source, path, user)
+        if repo._user is None:
+            repo._set_user(DEFAULT_USER)
         return repo
 
     def commit(

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -7,6 +7,12 @@ from giterator import Git, User
 from giterator.testing import Repo
 
 
+def check_config_user(git: Git, name: str, email: str) -> None:
+    config = (git.path / '.git' / 'config').read_text()
+    assert f'name = {name}' in config
+    assert f'email = {email}' in config
+
+
 class TestRepo:
 
     def test_commit_with_one_date(self, repo: Repo):
@@ -33,27 +39,43 @@ class TestRepo:
         upstream.commit_content('a')
         clone = Repo.clone(upstream, root / 'clone')
         tmpdir.compare(('clone', 'upstream'), recursive=False)
-        config = (clone.path / '.git' / 'config').read_text()
-        assert 'name = Giterator' in config
-        assert 'email = giterator@example.com' in config
+        check_config_user(clone, 'Giterator', 'giterator@example.com')
 
     def test_with_user(self, repo: Repo, tmpdir: TempDirectory):
         repo.commit_content('a')
         clone = Repo.clone(repo, 'clone', User('Foo', 'bar@example.com'))
         tmpdir.compare(('clone', 'repo'), recursive=False)
-        config = (clone.path / '.git' / 'config').read_text()
-        assert 'name = Foo' in config
-        assert 'email = bar@example.com' in config
+        check_config_user(clone, 'Foo', 'bar@example.com')
 
     def test_clone_from_path(self, tmpdir: TempDirectory):
         root = Path(tmpdir.path)
         upstream = Repo.make(root / 'upstream')
         upstream.commit_content('a')
         clone = Repo.clone(upstream.path, root / 'clone')
-        config = (clone.path / '.git' / 'config').read_text()
-        assert 'name = Giterator' in config
-        assert 'email = giterator@example.com' in config
+        check_config_user(clone, 'Giterator', 'giterator@example.com')
         clone.commit_content('b')  # commits never depend on global git config
+
+    def test_clone_from_str(self, repo: Repo, tmpdir: TempDirectory):
+        repo.commit_content('a')
+        clone = Repo.clone(str(repo.path), 'clone')
+        check_config_user(clone, 'Giterator', 'giterator@example.com')
+
+    def test_clone_from_path_with_user(self, repo: Repo, tmpdir: TempDirectory):
+        repo.commit_content('a')
+        clone = Repo.clone(repo.path, 'clone', User('Foo', 'bar@example.com'))
+        check_config_user(clone, 'Foo', 'bar@example.com')
+
+    def test_clone_source_git_without_user(self, repo: Repo, tmpdir: TempDirectory):
+        repo.commit_content('a')
+        clone = Repo.clone(Git(repo.path), 'clone')
+        check_config_user(clone, 'Giterator', 'giterator@example.com')
+
+    def test_clone_inherits_source_user(self, tmpdir: TempDirectory):
+        root = Path(tmpdir.path)
+        upstream = Repo.make(root / 'upstream', User(name='Foo Bar', email='foo@example.com'))
+        upstream.commit_content('a')
+        clone = Repo.clone(upstream, root / 'clone')
+        check_config_user(clone, 'Foo Bar', 'foo@example.com')
 
     def test_clone_non_testing(self, git: Git):
         (git.path / 'a').write_text('content')

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -45,6 +45,16 @@ class TestRepo:
         assert 'name = Foo' in config
         assert 'email = bar@example.com' in config
 
+    def test_clone_from_path(self, tmpdir: TempDirectory):
+        root = Path(tmpdir.path)
+        upstream = Repo.make(root / 'upstream')
+        upstream.commit_content('a')
+        clone = Repo.clone(upstream.path, root / 'clone')
+        config = (clone.path / '.git' / 'config').read_text()
+        assert 'name = Giterator' in config
+        assert 'email = giterator@example.com' in config
+        clone.commit_content('b')  # commits never depend on global git config
+
     def test_clone_non_testing(self, git: Git):
         (git.path / 'a').write_text('content')
         git.commit('a commit')


### PR DESCRIPTION
Fixes #1.

`Repo.make` guarantees a local committer identity, but `Repo.clone` only got one when its `source` was a `Git` instance (inherited via `_user`) — cloning from a plain path/str left the clone bare, so any commit made in it (or in a worktree of it) silently depended on the machine's global git config, and failed with *Author identity unknown* on machines that scope identity with `[includeIf "gitdir:…"]`.

This takes the second option from the issue: `giterator.testing.Repo.clone` now applies the same default identity as `Repo.make` whenever neither an explicit `user=` nor a `Git` source provides one (the default is factored into a shared `DEFAULT_USER`). `Git.clone` is deliberately unchanged — a general-purpose clone shouldn't stamp a fake identity into real repos; hermeticity is the testing layer's contract.

The new `test_clone_from_path` commits in the clone, which reproduces the original failure red/green on an includeIf-scoped machine: it fails with *Author identity unknown* before the change and passes after. Full suite: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)