### PR TITLE
Pin the initial branch name for test repos

### DIFF
--- a/giterator/git.py
+++ b/giterator/git.py
@@ -67,16 +67,21 @@ class Git:
             self('config', 'user.name', user.name)
             self('config', 'user.email', user.email)
 
-    def init(self, user: User = None) -> None:
+    def init(self, user: User = None, branch: str = None) -> None:
         """
         Create an empty Git repository or reinitialize an existing one.
         If the path doesn't exist, it will be created. This includes any missing
         parent directories.
 
         :param user: The user to configure in the local repo.
+        :param branch: The name to use for the initial branch. If not specified,
+            the machine's git default is used.
         """
         makedirs(self.path, exist_ok=True)
-        self('init')
+        command = ['init']
+        if branch:
+            command.extend(['-b', branch])
+        self(*command)
         self._set_user(user)
 
     @classmethod

--- a/giterator/testing.py
+++ b/giterator/testing.py
@@ -8,6 +8,7 @@ from .typing import Date
 
 
 DEFAULT_USER = User(name='Giterator', email='giterator@example.com')
+DEFAULT_BRANCH = 'main'
 
 
 class Repo(Git):
@@ -20,13 +21,16 @@ class Repo(Git):
         self._clock = Clock()
 
     @classmethod
-    def make(cls, path: Union[Path, str], user: User = None) -> 'Repo':
+    def make(
+            cls, path: Union[Path, str], user: User = None, branch: str = DEFAULT_BRANCH
+    ) -> 'Repo':
         """
-        Make a repo at the path specified and ensure a user is configured
-        in the repo. The user can be specified.
+        Make a repo at the path specified and ensure a user and initial branch
+        name are configured in the repo, so neither depends on the git config
+        of the machine the tests are running on. Both can be specified.
         """
         repo = cls(path)
-        repo.init(user or DEFAULT_USER)
+        repo.init(user or DEFAULT_USER, branch)
         return repo
 
     @classmethod

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -34,6 +34,11 @@ class TestInit:
         assert b'name = Foo Bar' in config
         assert b'email = foo@example.com' in config
 
+    def test_init_with_branch(self, tmpdir: TempDirectory):
+        git = Git(tmpdir.getpath('foo'))
+        git.init(branch='trunk')
+        compare(git('symbolic-ref', 'HEAD'), expected='refs/heads/trunk\n')
+
 
 class TestClone:
 

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pathlib import Path
 
+import pytest
 from testfixtures import compare, TempDirectory
 
 from giterator import Git, User
@@ -32,6 +33,21 @@ class TestRepo:
         repo.commit('commit', author_date=datetime(2000, 1, 1), commit_date=datetime(2000, 1, 2))
         compare(repo.git('log', '--pretty=format:%ad'), expected='Sat Jan 1 00:00:00 2000 +0000')
         compare(repo.git('log', '--pretty=format:%cd'), expected='Sun Jan 2 00:00:00 2000 +0000')
+
+    def test_make_default_branch_ignores_machine_config(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        config = tmp_path / 'gitconfig'
+        config.write_text('[init]\n\tdefaultBranch = unexpected\n')
+        monkeypatch.setenv('GIT_CONFIG_GLOBAL', str(config))
+        repo = Repo.make(tmp_path / 'repo')
+        repo.commit_content('a')
+        compare(repo.branches(), expected=['main'])
+
+    def test_make_with_branch(self, tmp_path: Path):
+        repo = Repo.make(tmp_path / 'repo', branch='trunk')
+        repo.commit_content('a')
+        compare(repo.branches(), expected=['trunk'])
 
     def test_clone(self, tmpdir: TempDirectory):
         root = Path(tmpdir.path)


### PR DESCRIPTION
## Summary

The initial branch of repos giterator creates came from the machine's `init.defaultBranch`: `master` on stock git, `main` where it's been set, anything at all otherwise. Downstream tests that assert on branch names, resolve `HEAD`'s branch in a clone, or push to a named branch then pass or fail depending on the developer's git config — the same hermeticity failure mode as #1, for branch names instead of committer identity.

- `Git.init` grows an opt-in `branch` parameter (`git init -b`), so real-world behaviour is unchanged unless requested.
- `Repo.make` pins `main` by default, overridable in the same way as `user`.

## Test plan

- New `test_init_with_branch` covers the `Git.init` parameter.
- New `test_make_default_branch_ignores_machine_config` is hermetic: it points `GIT_CONFIG_GLOBAL` at a config with `defaultBranch = unexpected` and asserts `Repo.make` still produces `main` — verified to fail (producing `['unexpected']`) without the fix.
- New `test_make_with_branch` covers overriding the pinned default.
- Full suite: 43 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)